### PR TITLE
fix: fails value in access filter is overwritten from subsequent filters

### DIFF
--- a/multi_data_monitor/src/plugin/filter/access.cpp
+++ b/multi_data_monitor/src/plugin/filter/access.cpp
@@ -55,7 +55,7 @@ Packet Access::apply(const Packet & packet)
   {
     if (!value[field])
     {
-      value.reset(value_);
+      value.reset(YAML::Clone(value_));
       break;
     }
     value.reset(value[field]);


### PR DESCRIPTION
Fix a bug where `fails` value in access filter is overwritten from subsequent filters.